### PR TITLE
Region invalid s3 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | The name to give the bucket where the statefile will be stored (Must be 32 characters or less) | `string` | n/a | yes |
 | <a name="input_principal_arns"></a> [principal\_arns](#input\_principal\_arns) | List of ARNs to grant access to the KMS key (if use\_kms is true) | `list(string)` | `[]` | no |
-| <a name="input_region"></a> [region](#input\_region) | The AWS Region to place the resources in | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources | `map(string)` | `{}` | no |
 | <a name="input_use_kms"></a> [use\_kms](#input\_use\_kms) | Whether to use KMS encryption or not | `bool` | `false` | no |
 

--- a/log.tf
+++ b/log.tf
@@ -1,8 +1,6 @@
 resource "aws_s3_bucket" "this-logs" {
   bucket_prefix = "${var.bucket_prefix}-logs"
-  region        = var.region
-
-  tags = var.tags
+  tags          = var.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "this-logs" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "this" {
   bucket_prefix = var.bucket_prefix
-  region        = var.region
   tags          = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,8 +20,3 @@ variable "tags" {
   description = "Tags to apply to the resources"
   default     = {}
 }
-
-variable "region" {
-  type        = string
-  description = "The AWS Region to place the resources in"
-}


### PR DESCRIPTION
- Remove `var.region` as no resources utilize it after change
- Remove `region` argument from all s3 buckets as region is not configurable and is inherited from provider