### PR TITLE
Fix KMS path so use_kms = true is actually usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ terraform {
 
 ### Example of usage utilizing KMS encryption:
 
-:warning: **Enabling KMS requires a list of principal ARNs that will be granted access to the KMS key. All users added to this will have full access over the provisioned key** :warning:
+:warning: **Enabling KMS requires a non-empty `principal_arns` list. Each ARN is granted both administrative and data-plane access to the provisioned key (i.e. they can manage the key *and* encrypt/decrypt state files with it). The AWS account root retains full access via the standard lockout-protection statement.** :warning:
 
 ```hcl
 module "s3_backend" {
@@ -114,14 +114,14 @@ No modules.
 | [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.this-logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_iam_policy_document.kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The name prefix to give the bucket where the statefile and lockfile will be stored (Must be 23 characters or less) | `string` | n/a | yes |
-| <a name="input_principal_arns"></a> [principal\_arns](#input\_principal\_arns) | List of ARNs to grant access to the KMS key (if use\_kms is true) | `list(string)` | `[]` | no |
+| <a name="input_principal_arns"></a> [principal\_arns](#input\_principal\_arns) | List of ARNs granted administrative and data-plane access to the KMS key. Required (non-empty) when use\_kms is true. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources | `map(string)` | `{}` | no |
 | <a name="input_use_kms"></a> [use\_kms](#input\_use\_kms) | Whether to use KMS encryption or not | `bool` | `false` | no |
 

--- a/kms.tf
+++ b/kms.tf
@@ -1,41 +1,54 @@
+data "aws_caller_identity" "current" {
+  count = var.use_kms ? 1 : 0
+}
+
+locals {
+  kms_policy = var.use_kms ? {
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableAccountRootKMSAccess"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current[0].account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowOperatorsToAdministerAndUseKey"
+        Effect    = "Allow"
+        Principal = { AWS = var.principal_arns }
+        Action = [
+          "kms:Describe*",
+          "kms:Get*",
+          "kms:List*",
+          "kms:Enable*",
+          "kms:Disable*",
+          "kms:Update*",
+          "kms:Put*",
+          "kms:Revoke*",
+          "kms:CreateGrant",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+        ]
+        Resource = "*"
+      },
+    ]
+  } : null
+}
+
 resource "aws_kms_key" "this" {
   count = var.use_kms ? 1 : 0
 
   description = "Terraform Backend KMS Key"
-  policy      = data.aws_iam_policy_document.kms_policy
+  policy      = jsonencode(local.kms_policy)
 
   enable_key_rotation = true
 
   tags = var.tags
-
-}
-
-data "aws_iam_policy_document" "kms_policy" {
-  count = var.use_kms ? 1 : 0
-
-  statement {
-    sid = "Enable IAM User Permissions for KMS key"
-
-    actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Update*",
-      "kms:Revoke*",
-      "kms:Disable*",
-      "kms:Get*",
-      "kms:Delete*",
-      "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion",
-    ]
-
-    resources = ["*"]
-
-    principals {
-      type        = "AWS"
-      identifiers = var.principal_arns
-    }
-  }
 }

--- a/tests/unit/smoke.tftest.hcl
+++ b/tests/unit/smoke.tftest.hcl
@@ -10,3 +10,40 @@ variables {
 run "default_no_kms" {
   command = plan
 }
+
+run "with_kms" {
+  command = apply
+
+  variables {
+    use_kms        = true
+    principal_arns = ["arn:aws:iam::123456789012:role/operator"]
+  }
+
+  assert {
+    condition     = one(aws_s3_bucket_server_side_encryption_configuration.this.rule).apply_server_side_encryption_by_default[0].sse_algorithm == "aws:kms"
+    error_message = "When use_kms = true, the state bucket SSE configuration must use aws:kms"
+  }
+
+  assert {
+    condition     = strcontains(aws_kms_key.this[0].policy, "kms:Decrypt")
+    error_message = "KMS policy must grant kms:Decrypt so principals can read encrypted state"
+  }
+
+  assert {
+    condition     = strcontains(aws_kms_key.this[0].policy, "kms:GenerateDataKey")
+    error_message = "KMS policy must grant kms:GenerateDataKey so S3 can write encrypted state"
+  }
+}
+
+run "kms_requires_principal_arns" {
+  command = plan
+
+  variables {
+    use_kms        = true
+    principal_arns = []
+  }
+
+  expect_failures = [
+    var.principal_arns,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,13 @@ variable "use_kms" {
 
 variable "principal_arns" {
   type        = list(string)
-  description = "List of ARNs to grant access to the KMS key (if use_kms is true)"
+  description = "List of ARNs granted administrative and data-plane access to the KMS key. Required (non-empty) when use_kms is true."
   default     = []
+
+  validation {
+    condition     = !var.use_kms || length(var.principal_arns) > 0
+    error_message = "principal_arns must contain at least one ARN when use_kms is true."
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
Closes #18.

## Summary

- **`kms.tf:5` policy reference is corrected.** The original `policy = data.aws_iam_policy_document.kms_policy` assignment failed at plan time because the data source had `count = 1` (so it was a tuple) and `aws_kms_key.policy` wants a JSON string, not the data-source object.
- **The KMS policy now actually permits S3 to use the key.** The pre-existing policy listed only administrative actions; `kms:Encrypt` / `kms:Decrypt` / `kms:GenerateDataKey*` were missing. With the syntax bug alone fixed, a freshly-applied bucket would have failed at first write with `AccessDenied`. Even though the syntax fix would have made plans succeed, the path was still broken end-to-end.
- **Replaced the `aws_iam_policy_document` data source with a `local` + `jsonencode()`.** Two statements now: AWS account-root lockout protection (`kms:*`) and an operator statement granting `principal_arns` admin + data-plane perms on this key. `kms:Create*` is dropped (meaningless on a key-resource policy).
- **`principal_arns` is now validated as non-empty when `use_kms = true`.** Previously the variable defaulted to `[]`, so `use_kms = true` with defaults produced a key policy with no principals.
- **Re-adds the `with_kms` unit test that PR #19 dropped**, plus a `kms_requires_principal_arns` `expect_failures` run for the new validation.

This is a **patch release**, not a breaking change — the `use_kms = true` path was never functional, so no consumer can be relying on the prior behavior.

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes
- [x] `terraform test -test-directory=tests/unit` passes locally — three runs (`default_no_kms`, `with_kms`, `kms_requires_principal_arns`) all green
- [ ] CI passes `terraform-unit-test` on the new test layout

## Notes

- Issue #20 (modernize testing framework / CI workflow consolidation) covers the broader refactor of this test file — this PR keeps test scope minimal and additive.
- The `terraform-docs` block in README was hand-edited (added `aws_caller_identity`, removed `aws_iam_policy_document.kms_policy`, refreshed `principal_arns` description); CI's `terraform-docs` action will normalize on merge.